### PR TITLE
Reduce overhead of validation by removing unnecessary promise wrapping

### DIFF
--- a/src/frameworks/express.js
+++ b/src/frameworks/express.js
@@ -1,11 +1,10 @@
 function getValidator(validateRequest) {
     return function validate(req, res, next) {
         const requestOptions = _getParameters(req);
-        validateRequest(requestOptions).then(function(errors) {
-            next(errors);
-        });
+        const errors = validateRequest(requestOptions);
+        next(errors);
     };
-};
+}
 
 function _getParameters(req) {
     const requestOptions = {};

--- a/src/frameworks/fastify.js
+++ b/src/frameworks/fastify.js
@@ -28,11 +28,11 @@ function getValidator(validateRequest) {
             return Promise.resolve();
         }
 
-        return validateRequest(requestOptions).then(function (errors) {
-            if (errors) {
-                throw errors;
-            }
-        });
+        const errors = validateRequest(requestOptions);
+        if (errors) {
+            return Promise.reject(errors);
+        }
+        return Promise.resolve();
     }
 
     function _getParameters(req) {

--- a/src/frameworks/koa.js
+++ b/src/frameworks/koa.js
@@ -1,7 +1,7 @@
 function getValidator(validateRequest) {
     return async function validate(ctx, next) {
         const requestOptions = _getParameters(ctx);
-        const errors = await validateRequest(requestOptions);
+        const errors = validateRequest(requestOptions);
         if (errors) {
             throw errors;
         }
@@ -21,6 +21,6 @@ function getValidator(validateRequest) {
 
         return requestOptions;
     }
-};
+}
 
 module.exports = { getValidator };


### PR DESCRIPTION
We were using promises mostly for the flow control, which is expensive performance-wise and redundant.