### PR TITLE
Add errorFormatter to ajvValidatorOptions types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -60,6 +60,7 @@ export interface ajvValidatorOptions {
     ajvConfigParams?: object;
     beautifyErrors?: boolean;
     contentTypeValidation?: boolean;
+    errorFormatter?: (errors: ErrorDetails, options: ajvValidatorOptions) => Error;
     expectFormFieldsInBody?: boolean;
     firstError?: boolean;
     framework?: frameworks;


### PR DESCRIPTION
Currently missing from the types