### PR TITLE
fix path finding in express

### DIFF
--- a/src/frameworks/express.js
+++ b/src/frameworks/express.js
@@ -8,6 +8,11 @@ function getValidator(validateRequest) {
 
 function _getParameters(req) {
     const requestOptions = {};
+    if (!req.route || !req.route.path) {
+      req.route = {
+        path: req.path
+      };
+    }
     const path = req.baseUrl.concat(req.route.path);
     requestOptions.path = path.endsWith('/') ? path.substring(0, path.length - 1) : path;
     requestOptions.headers = req.headers;


### PR DESCRIPTION
per https://github.com/PayU/openapi-validator-middleware/issues/81, borrow from @evelyne24's fix to use req.path if req.route does not exist.