### PR TITLE
Allow single file upload

### DIFF
--- a/src/frameworks/express.js
+++ b/src/frameworks/express.js
@@ -1,3 +1,4 @@
+const getRequestFiles = require("../utils/requestFilesExtractor")
 function getValidator(validateRequest) {
     return function validate(req, res, next) {
         const requestOptions = _getParameters(req);
@@ -13,13 +14,9 @@ function _getParameters(req) {
     requestOptions.headers = req.headers;
     requestOptions.params = req.params;
     requestOptions.query = req.query;
-    requestOptions.files = req.files;
     requestOptions.method = req.method;
     requestOptions.body = req.body;
-    if (req.file || req.files) {
-        const files = req.files ? req.files : []
-        requestOptions.files = [req.file, ...files];
-    }
+    requestOptions.files = getRequestFiles(req);
 
     return requestOptions;
 }

--- a/src/frameworks/express.js
+++ b/src/frameworks/express.js
@@ -1,4 +1,5 @@
 const getRequestFiles = require("../utils/requestFilesExtractor")
+
 function getValidator(validateRequest) {
     return function validate(req, res, next) {
         const requestOptions = _getParameters(req);

--- a/src/frameworks/express.js
+++ b/src/frameworks/express.js
@@ -16,6 +16,10 @@ function _getParameters(req) {
     requestOptions.files = req.files;
     requestOptions.method = req.method;
     requestOptions.body = req.body;
+    if (req.file || req.files) {
+        const files = req.files ? req.files : []
+        requestOptions.files = [req.file, ...files];
+    }
 
     return requestOptions;
 }

--- a/src/frameworks/express.js
+++ b/src/frameworks/express.js
@@ -1,4 +1,4 @@
-const getRequestFiles = require("../utils/requestFilesExtractor")
+const getRequestFiles = require('../utils/requestFilesExtractor');
 
 function getValidator(validateRequest) {
     return function validate(req, res, next) {

--- a/src/frameworks/fastify.js
+++ b/src/frameworks/fastify.js
@@ -1,4 +1,6 @@
 const fp = require('fastify-plugin');
+const getRequestFiles = require("../utils/requestFilesExtractor")
+
 let urijs;
 
 function getValidator(validateRequest) {
@@ -42,7 +44,7 @@ function getValidator(validateRequest) {
         requestOptions.headers = req.headers;
         requestOptions.params = req.params;
         requestOptions.query = req.query;
-        requestOptions.files = req.files;
+        requestOptions.files = getRequestFiles(req);
         requestOptions.method = req.raw.method;
         requestOptions.body = req.body;
 

--- a/src/frameworks/fastify.js
+++ b/src/frameworks/fastify.js
@@ -1,5 +1,5 @@
 const fp = require('fastify-plugin');
-const getRequestFiles = require("../utils/requestFilesExtractor")
+const getRequestFiles = require('../utils/requestFilesExtractor');
 
 let urijs;
 

--- a/src/frameworks/koa.js
+++ b/src/frameworks/koa.js
@@ -1,3 +1,5 @@
+const getRequestFiles = require("../utils/requestFilesExtractor")
+
 function getValidator(validateRequest) {
     return async function validate(ctx, next) {
         const requestOptions = _getParameters(ctx);
@@ -15,7 +17,7 @@ function getValidator(validateRequest) {
         requestOptions.headers = ctx.request.req.headers;
         requestOptions.params = ctx.params;
         requestOptions.query = ctx.query;
-        requestOptions.files = ctx.req.files;
+        requestOptions.files = getRequestFiles(ctx.req);
         requestOptions.method = ctx.req.method;
         requestOptions.body = ctx.req.body || ctx.request.body;
 

--- a/src/frameworks/koa.js
+++ b/src/frameworks/koa.js
@@ -1,4 +1,4 @@
-const getRequestFiles = require("../utils/requestFilesExtractor")
+const getRequestFiles = require('../utils/requestFilesExtractor');
 
 function getValidator(validateRequest) {
     return async function validate(ctx, next) {

--- a/src/utils/requestFilesExtractor.js
+++ b/src/utils/requestFilesExtractor.js
@@ -1,9 +1,9 @@
 module.exports = (req) => {
     if (req.file || req.files) {
-        const files = req.files ? req.files : []
+        const files = req.files ? req.files : [];
         if (req.file) {
             files.push(req.file);
         }
         return files;
     }
-}
+};

--- a/src/utils/requestFilesExtractor.js
+++ b/src/utils/requestFilesExtractor.js
@@ -1,0 +1,9 @@
+module.exports = (req) => {
+    if (req.file || req.files) {
+        const files = req.files ? req.files : []
+        if (req.file) {
+            files.push(req.file);
+        }
+        return files;
+    }
+}

--- a/test/express/middleware-test.js
+++ b/test/express/middleware-test.js
@@ -2332,6 +2332,20 @@ describe('input-validation middleware tests - Express', function () {
                     done();
                 });
         });
+        it('supports single file upload', function (done) {
+            request(app)
+                .post('/singleFile')
+                .set('api-version', '1.0')
+                .attach('image', 'LICENSE')
+                .expect(200, function (err, res) {
+                    if (err) {
+                        throw err;
+                    }
+                    expect(res.body.result).to.equal('OK');
+                    done();
+                });
+        });
+
     });
     describe('Keywords', function () {
         let app;

--- a/test/express/middleware-test.js
+++ b/test/express/middleware-test.js
@@ -2345,7 +2345,6 @@ describe('input-validation middleware tests - Express', function () {
                     done();
                 });
         });
-
     });
     describe('Keywords', function () {
         let app;

--- a/test/express/test-server-formdata.js
+++ b/test/express/test-server-formdata.js
@@ -37,7 +37,7 @@ module.exports = () => {
     app.post('/login', upload.any(), inputValidation.validate, function (req, res, next) {
         res.json({ result: 'OK' });
     });
-    app.post('/singleFile', upload.single("image"), inputValidation.validate, function (req, res, next) {
+    app.post('/singleFile', upload.single('image'), inputValidation.validate, function (req, res, next) {
         res.json({ result: 'OK' });
     });
     app.use(function (err, req, res, next) {

--- a/test/express/test-server-formdata.js
+++ b/test/express/test-server-formdata.js
@@ -37,6 +37,9 @@ module.exports = () => {
     app.post('/login', upload.any(), inputValidation.validate, function (req, res, next) {
         res.json({ result: 'OK' });
     });
+    app.post('/singleFile', upload.single("image"), inputValidation.validate, function (req, res, next) {
+        res.json({ result: 'OK' });
+    });
     app.use(function (err, req, res, next) {
         if (err instanceof inputValidation.InputValidationError) {
             res.status(400).json({ more_info: err.errors });

--- a/test/form-data-swagger.yaml
+++ b/test/form-data-swagger.yaml
@@ -75,6 +75,22 @@ paths:
       responses:
         '200':
           description: Import result
+  /singleFile:
+    post:
+      description: Single file upload
+      produces:
+        - application/json
+      consumes:
+        - multipart/form-data
+      parameters:
+        - name: image
+          in: formData
+          required: true
+          type: file
+          description: File to upload from.
+      responses:
+        '200':
+          description: Import result
 definitions:
 
 parameters:

--- a/test/koa/middleware-test.js
+++ b/test/koa/middleware-test.js
@@ -2345,6 +2345,19 @@ describe('input-validation middleware tests - Koa', function () {
                     done();
                 });
         });
+        it('supports single file upload', function (done) {
+            request(app)
+                .post('/singleFile')
+                .set('api-version', '1.0')
+                .attach('image', 'LICENSE')
+                .expect(200, function (err, res) {
+                    if (err) {
+                        throw err;
+                    }
+                    expect(res.body.result).to.equal('OK');
+                    done();
+                });
+        });
     });
     describe('Keywords', function () {
         let app;

--- a/test/koa/test-server-formdata.js
+++ b/test/koa/test-server-formdata.js
@@ -50,7 +50,7 @@ module.exports = () => {
         ctx.status = 200;
         ctx.body = { result: 'OK' };
     });
-    router.post('/singleFile', upload.single("image"), inputValidation.validate, function (ctx, next) {
+    router.post('/singleFile', upload.single('image'), inputValidation.validate, function (ctx, next) {
         ctx.status = 200;
         ctx.body = { result: 'OK' };
     });

--- a/test/koa/test-server-formdata.js
+++ b/test/koa/test-server-formdata.js
@@ -50,6 +50,10 @@ module.exports = () => {
         ctx.status = 200;
         ctx.body = { result: 'OK' };
     });
+    router.post('/singleFile', upload.single("image"), inputValidation.validate, function (ctx, next) {
+        ctx.status = 200;
+        ctx.body = { result: 'OK' };
+    });
 
     return app;
 };


### PR DESCRIPTION
Both `req.files` and `req.file` must be considered for handling `multipart/form-data` validation. This is necessary to allow uploading of a [single ](https://www.npmjs.com/package/multer#singlefieldname )file with multer. Otherwise something like `upload.single("image")` will not work.

This is a small and important fix. However, it does not improve the validation itself. Without this fix, uploading a single file will cause `requestOptions.files` to be `undefined`. But the validation passes anyway. The same when no file is uploaded at all!