### PR TITLE
fix: match route with empty path parameters for api with child resource

### DIFF
--- a/src/utils/schemaEndpointResolver.js
+++ b/src/utils/schemaEndpointResolver.js
@@ -31,7 +31,7 @@ function _pathMatcherInternal(routes, path, exactMatch) {
 
                 if (!exactMatch) {
                     // if current path segment is param
-                    if (seg.startsWith(':') && pathArr[idx]) return true;
+                    if (seg.startsWith(':') && (idx in pathArr)) return true;
                 }
 
                 return false;

--- a/test/express/middleware-test.js
+++ b/test/express/middleware-test.js
@@ -345,6 +345,22 @@ describe('input-validation middleware tests - Express', function () {
                     done();
                 });
         });
+        it('bad path param - wrong format empty string', function (done) {
+            request(app)
+                .get('/pets/')
+                .set('request-id', '1234')
+                .set('api-version', '1.0')
+                .query({ limit: '50', page: 0 })
+                .expect(400, function (err, res) {
+                    if (err) {
+                        throw err;
+                    }
+                    const moreInfoAsJson = JSON.parse(res.body.more_info);
+                    expect(moreInfoAsJson).to.be.instanceof(Array);
+                    expect(res.body.more_info).to.includes('petId');
+                    done();
+                });
+        });
         it('bad body - wrong format nested attribute (not parameters)', function (done) {
             request(app)
                 .put('/pets')

--- a/test/express/middleware-test.js
+++ b/test/express/middleware-test.js
@@ -345,22 +345,6 @@ describe('input-validation middleware tests - Express', function () {
                     done();
                 });
         });
-        it('bad path param - wrong format empty string', function (done) {
-            request(app)
-                .get('/pets/')
-                .set('request-id', '1234')
-                .set('api-version', '1.0')
-                .query({ limit: '50', page: 0 })
-                .expect(400, function (err, res) {
-                    if (err) {
-                        throw err;
-                    }
-                    const moreInfoAsJson = JSON.parse(res.body.more_info);
-                    expect(moreInfoAsJson).to.be.instanceof(Array);
-                    expect(res.body.more_info).to.includes('petId');
-                    done();
-                });
-        });
         it('bad body - wrong format nested attribute (not parameters)', function (done) {
             request(app)
                 .put('/pets')

--- a/test/fastify/fastify-test.js
+++ b/test/fastify/fastify-test.js
@@ -29,6 +29,10 @@ describe('fastify plugin', () => {
         app.get('/pets', (req, reply) => {
             reply.status(204).send();
         });
+        
+        app.get('/pets/:petId/medicalHistory', (req, reply) => {
+            reply.status(204).send();
+        });
 
         app.post('/pets', (req, reply) => {
             reply.status(201).send();
@@ -105,5 +109,23 @@ describe('fastify plugin', () => {
                 test: 'field1'
             }).post('/pets');
         expect(response.statusCode).to.equal(400);
+    });
+    it('Invalid path parameter - too short', async () => {
+        const response = await app.inject()
+            .headers({
+                'api-version': '1.0'
+            })
+            .get('/pets/11/medicalHistory');
+        expect(response.statusCode).to.equal(400);
+        console.log(response);
+    });
+    it('Invalid path parameter - empty', async () => {
+        const response = await app.inject()
+            .headers({
+                'api-version': '1.0'
+            })
+            .get('/pets//medicalHistory');
+        expect(response.statusCode).to.equal(400);
+        console.log(response);
     });
 });

--- a/test/fastify/fastify-test.js
+++ b/test/fastify/fastify-test.js
@@ -29,7 +29,7 @@ describe('fastify plugin', () => {
         app.get('/pets', (req, reply) => {
             reply.status(204).send();
         });
-        
+
         app.get('/pets/:petId/medicalHistory', (req, reply) => {
             reply.status(204).send();
         });

--- a/test/pet-store-swagger.yaml
+++ b/test/pet-store-swagger.yaml
@@ -226,6 +226,68 @@ paths:
           description: unexpected error
           schema:
             $ref: '#/definitions/Error'
+  /pets/{petId}/medicalHistory:
+    get:
+      summary: Medical history for a specific pet
+      operationId: medicalHistoryByPetId
+      tags:
+        - pets
+      parameters:
+        - $ref: '#/parameters/ApiVersion'
+        - $ref: '#/parameters/ApiRequestId'
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          type: string
+          minLength: 3
+          maxLength: 10
+      responses:
+        "200":
+          description: Expected response to a valid request
+          schema:
+            $ref: '#/definitions/Pets'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    put:
+      summary: Medical history for a specific pet
+      operationId: medicalHistoryByPetId
+      tags:
+        - pets
+      consumes:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/ApiVersion'
+        - $ref: '#/parameters/ApiRequestId'
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          type: string
+          minLength: 3
+          maxLength: 10
+        - name: body
+          in: body
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+              age:
+                type: integer
+              tag:
+                type: string
+      responses:
+        "200":
+          description: Expected response to a valid request
+          schema:
+            $ref: '#/definitions/Pets'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
   /pets/search:
     get:
       summary: Search for a pet


### PR DESCRIPTION
Cover validation in cases when path parameter is empty.